### PR TITLE
Added Dockerfile and instructions to use the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM composer:latest AS builder
+COPY . /app
+WORKDIR /app
+RUN composer install --no-dev
+RUN chmod +x ./redlog
+RUN rm -Rf .env
+
+FROM php:7.3-cli
+COPY --from=builder /app /app
+VOLUME /app/.env
+WORKDIR /app
+ENTRYPOINT [ "php", "./redlog" ]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Thus, configure a `REDMINE_SESSION` in `.env` (taken from the `_redmine_session`
 cookie from a browser in which you are authenticated), so that redlog
 gets that list via HTTP call.
 
+### Docker image
+A Docker image [is available on Docker Hub](https://hub.docker.com/r/bitbull/redlog) , and it's built from the included Dockerfile. You can invoke the command with:
+
+    docker run -v $(pwd)/.env:/app/.env -v $(pwd)/config.yml:/app/config.yml bitbull/redlog log 2020-04-27 1000-1315 1234  d  "Fixed nasty bug"
+
 ## Contributing
 Contributions are very welcome; refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file for further details.
 


### PR DESCRIPTION
Please note: right now the image on Docker Hub is not automatically in sync with the repo, and only the "latest" tage is available. A possible enhancement could be to setup something like a Github Action to automatically build new image tags when a repository tag is created.